### PR TITLE
ysg 25.06.05 user11

### DIFF
--- a/src/main/java/com/example/yedocb/config/SecurityConfig.java
+++ b/src/main/java/com/example/yedocb/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/user/find_password").permitAll() // 비밀번호 찾기
                         .requestMatchers("/api/user/register").permitAll() // 사용자 회원가입
                         .requestMatchers("/api/admin/login").permitAll() // 관리자 로그인
+                        .requestMatchers("/api/user/refresh").permitAll() // 사용자 JWT 토큰 재 갱신
 
                         .requestMatchers("/api/reserve/disabled-times", "/api/reserve/disabled-times/**").permitAll()// 예약확인용
 

--- a/src/main/java/com/example/yedocb/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/yedocb/jwt/JwtAuthenticationFilter.java
@@ -49,7 +49,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             uri.equals("/api/user/find_id") ||
             uri.equals("/api/user/find_password") ||
             uri.equals("/api/admin/login") ||
-            uri.equals("/api/hello")) {
+            uri.equals("/api/hello") ||
+        	uri.equals("/api/user/refresh")){
 
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/com/example/yedocb/user/info/UserController.java
+++ b/src/main/java/com/example/yedocb/user/info/UserController.java
@@ -84,7 +84,7 @@ public class UserController {
     }
     
     // 회원 탈퇴 : uId 기준으로 사용자 정보 삭제
-    @PostMapping("/{uId}") 
+    @PostMapping("/Delete/{uId}") 
     public ResponseEntity<String> deleteUser(@PathVariable("uId") String uId, 
     										 @RequestHeader("Authorization") String token) {
     	
@@ -132,4 +132,32 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 정보로 사용자를 찾을 수 없습니다.");
         }
     }
+    
+    @GetMapping("/myinfo")
+    public ResponseEntity<User> getMyInfo(@RequestHeader("Authorization") String token){
+    	
+    	//JWT에서 uId 추출
+    	String userIdFromToken = jwtTokenProvider.getUserId(token.replace("Bearer ", ""));
+    	
+    	// uId로 DB 조회
+    	User user = userService.getUserInfoForMypage(userIdFromToken);
+    	
+    	if (user == null) {
+    		throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다.");
+    	}
+    	
+    	return ResponseEntity.ok(user);
+    }
+    	
+    @GetMapping("/{uId}")
+    public ResponseEntity<String> verifyUser(@PathVariable("uId") String uId,
+            @RequestHeader("Authorization") String token) {
+    	String userIdFromToken = jwtTokenProvider.getUserId(token.replace("Bearer ", ""));
+
+    	if (!uId.equals(userIdFromToken)) {
+    		throw new ResponseStatusException(HttpStatus.FORBIDDEN, "토큰 사용자와 요청한 ID가 일치하지 않습니다.");
+    	}
+
+    	return ResponseEntity.ok("사용자 인증 성공");
+    	}
 }

--- a/src/main/java/com/example/yedocb/user/info/UserService.java
+++ b/src/main/java/com/example/yedocb/user/info/UserService.java
@@ -17,4 +17,7 @@ public interface UserService {
     
     // 사용자 비밀번호 찾기
     User findUserPassword(String uId, String uEmail); // 임시 비밀번호를 직접 반환
+    
+    // 사용자 정보
+    User getUserInfoForMypage(String uid);
 }

--- a/src/main/java/com/example/yedocb/user/info/UserServiceImpl.java
+++ b/src/main/java/com/example/yedocb/user/info/UserServiceImpl.java
@@ -111,4 +111,8 @@ public class UserServiceImpl implements UserService {
         return null;
     }
     
+    @Override
+    public User getUserInfoForMypage(String uId) {
+    	return userMapper.selectUserInfoForMypage(uId);
+    }
 }

--- a/src/main/java/com/example/yedocb/user/login/UserLoginController.java
+++ b/src/main/java/com/example/yedocb/user/login/UserLoginController.java
@@ -4,9 +4,12 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.example.yedocb.jwt.JwtTokenProvider;
 import com.example.yedocb.user.entity.User;
@@ -15,44 +18,80 @@ import com.example.yedocb.user.entity.User;
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
 public class UserLoginController {
-	
+
     private final UserLoginService userLoginService;
     private final JwtTokenProvider jwtTokenProvider; // JwtTokenProvider 주입
+
+    // RefreshToken 저장소 (현재 In-Memory Map 사용 중 → 운영 시 반드시 DB 또는 Redis 사용해야 함)
+    private final Map<String, String> refreshTokenStore = new ConcurrentHashMap<>();
 
     @PostMapping("/login")
     public ResponseEntity<Map<String, String>> loginUser(@RequestBody Map<String, String> loginData) {
         String uId = loginData.get("uId");
         String uPwd = loginData.get("uPwd");
-        
+
         User user = userLoginService.login(uId, uPwd);
-        
+
         if (user != null) {
-        	
+
             // 여기서 Role 은 임시로 "USER" (나중에 DB 에서 가져와도 됨)
             List<String> roles = List.of("USER");
 
             // JWT 발급
             String token = jwtTokenProvider.createToken(uId, roles);
 
+            // Refresh Token 발급
+            String refreshToken = jwtTokenProvider.createRefreshToken(uId);
+
+            // Refresh Token 저장 (현재 Map 사용, 추후 DB/Redis 교체 필요)
+            refreshTokenStore.put(uId, refreshToken);
+
             // JWT 토큰 반환
             // 로그인 성공 시 프론트엔드에 전달할 응답 데이터 구성
             Map<String, String> responseBody = Map.of(
-            	    "token", token, // JWT 토큰 값
-            	    "uId", uId, // 로그인한 사용자 ID (프론트에서 사용자 표시나 관리용으로 사용함)
-            	    "uName", user.getUName() // 사용자 이름 추가
-            	);
-            
+                    "token", token, // JWT 토큰 값
+                    "refreshToken", refreshToken, // 추가: Refresh Token
+                    "uId", uId, // 로그인한 사용자 ID (프론트에서 사용자 표시나 관리용으로 사용함)
+                    "uName", user.getUName() // 사용자 이름 추가
+            );
+
             return ResponseEntity.ok(responseBody);
         } else {
             Map<String, String> errorResponse = Map.of("error", "Login failed");
             return ResponseEntity.status(401).body(errorResponse);
         }
     }
-    
+
     @PostMapping("/logout")
     public ResponseEntity<String> logoutUser(@RequestHeader("Authorization") String token) {
 
         // 프론트에서 JWT 삭제하도록 유도 (설계서: 클라이언트에 저장된 JWT 삭제 후 인증 종료 처리)
         return ResponseEntity.ok("로그아웃 완료 (프론트에서 토큰 삭제 필요)");
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<String> refresh(@RequestHeader("Authorization") String refreshToken) {
+
+        // Refresh Token 유효성 검사
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+        	throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Refresh Token 유효하지 않음");
+        }
+
+        // 사용자 ID 추출
+        String userId = jwtTokenProvider.getUserId(refreshToken);
+
+        // 저장된 Refresh Token 과 비교
+        String savedRefreshToken = refreshTokenStore.get(userId);
+
+        if (savedRefreshToken == null || !refreshToken.equals(savedRefreshToken)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Refresh Token 불일치");
+        }
+
+        // 새 Access Token 발급
+        List<String> roles = List.of("USER"); // 현재 고정값 → 필요 시 DB 에서 role 조회 가능
+        String newAccessToken = jwtTokenProvider.createToken(userId, roles);
+
+        // 새 Access Token 반환 (Refresh Token은 그대로 유지)
+        return ResponseEntity.ok(newAccessToken);
     }
 }

--- a/src/main/java/com/example/yedocb/user/repository/UserMapper.java
+++ b/src/main/java/com/example/yedocb/user/repository/UserMapper.java
@@ -34,4 +34,7 @@ public interface UserMapper {
 
     // 임시 비밀번호로 업데이트
     int updatePassword(@Param("uId") String uId, @Param("pwd") String pwd);
+    
+    // 마이페이지 정보
+    User selectUserInfoForMypage(String uId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,9 @@ mybatis.type-aliases-package=com.example.yedocb.user.entity,com.example.yedocb.a
 jwt.secret=bXlzZWNyZXRrZXlteXNlY3JldGtleW15c2VjcmV0a2V5bXlzZWNyZXRrZXk=
 jwt.expiration=3600000
 
+# 새로 추가 → RefreshToken 유효기간 (예: 7일 → 밀리초)
+jwt.refresh-expiration=604800000
+
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=yonsaibeauty0528@gmail.com

--- a/src/main/resources/repository/UserMapper.xml
+++ b/src/main/resources/repository/UserMapper.xml
@@ -9,8 +9,10 @@
     <update id="updateUserPhonePwd" parameterType="map">
         UPDATE users
         <set>
-            <if test="phone != null"> uPhone = #{phone}, </if>
-            <if test="pwd != null"> uPwd = #{pwd} </if>
+        	<trim suffixOverrides=",">
+            	<if test="phone != null"> uPhone = #{phone}, </if>
+            	<if test="pwd != null"> uPwd = #{pwd} </if>
+            </trim>
         </set>
         WHERE uId = #{uId}
     </update>
@@ -47,5 +49,9 @@
     	SET uPwd = #{pwd}
     	WHERE uId = #{uId}
 	</update>
+	
+	<select id="selectUserInfoForMypage" parameterType="string" resultType="com.example.yedocb.user.entity.User">
+   		SELECT uId, uName, uEmail, uPhone FROM users WHERE uId = #{uId}
+	</select>
 
 </mapper>


### PR DESCRIPTION
프로세스
로그인 성공 시 서버가 Access Token (1시간 짧은 토큰) / Refresh Token (일주일 긴 토큰) 발급
평소엔 Access Token으로 API를 호출함
Access Token 만료 시
서버 = 401 Unauthorized 에러 반환 / 프론트 Refresh Token으로 새 Access Token 요청 / 새 Access Token 받아 다시 저장 후 API 재요청
만약 Refresh Token도 만료 시 로그인 다시 해야함

역할 설명
Access Token 역할
= 인증된 사용자임을 증명하는 출입증 같은것 -> API 접근용

Refresh Token 역할
출입증 재 발급권 같은것 -> 새 토큰 요청용
= Access Token이 만료됐을 때만 사용 / 서버에 새 Access Token 발급 요청할 때 사용 / 서버는 Refresh Token을 별도로 저장/검증함